### PR TITLE
feat(summarizer): Claude認証情報ファイルマウント対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,9 @@ services:
       REDIS__HOST: redis
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      AI_PROVIDER: ${AI_PROVIDER:-auto}
+    volumes:
+      - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/summarizer/ai-integration.md
+++ b/docs/summarizer/ai-integration.md
@@ -88,6 +88,33 @@ claude
 claude --version
 ```
 
+### Claude認証情報の設定
+
+Dockerコンテナ内でClaude Codeを使用するため、ホストマシンの認証情報をマウントする必要があります。
+
+```bash
+# ホストマシンでClaude認証情報を設定
+claude  # 初回実行時に認証
+
+# 認証情報ファイルの確認
+ls ~/.claude/.credentials.json
+```
+
+Docker Composeでは以下の設定により認証情報をマウントします：
+
+```yaml
+summarizer-worker:
+  volumes:
+    - ~/.claude/.credentials.json:/root/.claude/.credentials.json:ro
+  environment:
+    AI_PROVIDER: claude-code
+```
+
+**重要事項**:
+- 認証情報ファイルは読み取り専用（`:ro`）でマウント
+- コンテナ内のパス: `/root/.claude/.credentials.json`
+- `AI_PROVIDER=claude-code`を設定してClaude Codeを優先使用
+
 ### 設定ファイル
 
 ```yaml

--- a/package/summarizer/tests/test_ai_client.py
+++ b/package/summarizer/tests/test_ai_client.py
@@ -143,7 +143,8 @@ def test_create_ai_client_no_api_key():  # type: ignore
 @pytest.mark.asyncio
 async def test_claude_code_generate_summary_success():  # type: ignore
     """Claude Code要約生成成功テスト."""
-    with patch('subprocess.run') as mock_run:
+    with patch('subprocess.run') as mock_run, \
+         patch('pathlib.Path.exists', return_value=True):
         # バージョンチェック用のmock
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="claude-code v1.0.0\n"),  # version check
@@ -163,7 +164,8 @@ async def test_claude_code_generate_summary_success():  # type: ignore
 @pytest.mark.asyncio
 async def test_claude_code_extract_keywords_success():  # type: ignore
     """Claude Codeキーワード抽出成功テスト."""
-    with patch('subprocess.run') as mock_run:
+    with patch('subprocess.run') as mock_run, \
+         patch('pathlib.Path.exists', return_value=True):
         # バージョンチェック用のmock
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="claude-code v1.0.0\n"),  # version check
@@ -183,7 +185,8 @@ async def test_claude_code_extract_keywords_success():  # type: ignore
 @pytest.mark.asyncio
 async def test_claude_code_not_available():  # type: ignore
     """Claude Code利用不可テスト."""
-    with patch('subprocess.run') as mock_run:
+    with patch('subprocess.run') as mock_run, \
+         patch('pathlib.Path.exists', return_value=True):
         mock_run.side_effect = FileNotFoundError("claude command not found")
 
         with pytest.raises(ExternalAPIError) as exc_info:
@@ -197,7 +200,8 @@ def test_create_ai_client_with_claude_code():  # type: ignore
     with patch('refnet_summarizer.clients.ai_client.settings') as mock_settings:
         mock_settings.ai_provider = "claude-code"
 
-        with patch('subprocess.run') as mock_run:
+        with patch('subprocess.run') as mock_run, \
+             patch('pathlib.Path.exists', return_value=True):
             mock_run.return_value = MagicMock(returncode=0, stdout="claude-code v1.0.0\n")
 
             client = create_ai_client()
@@ -211,7 +215,8 @@ def test_create_ai_client_auto_fallback():  # type: ignore
         mock_settings.openai_api_key = "test-openai-key"
         mock_settings.anthropic_api_key = None
 
-        with patch('subprocess.run') as mock_run:
+        with patch('subprocess.run') as mock_run, \
+             patch('pathlib.Path.exists', return_value=True):
             # Claude Code利用不可をシミュレート
             mock_run.side_effect = FileNotFoundError("claude command not found")
 
@@ -325,7 +330,8 @@ async def test_openai_extract_keywords_error():  # type: ignore
 @pytest.mark.asyncio
 async def test_claude_code_extract_keywords_failure():  # type: ignore
     """Claude Codeキーワード抽出失敗テスト."""
-    with patch('subprocess.run') as mock_run:
+    with patch('subprocess.run') as mock_run, \
+         patch('pathlib.Path.exists', return_value=True):
         # バージョンチェックは成功
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="claude-code v1.0.0\n"),  # version check
@@ -368,7 +374,8 @@ def test_create_ai_client_auto_fallback_to_anthropic():  # type: ignore
         mock_settings.openai_api_key = None
         mock_settings.anthropic_api_key = "test-anthropic-key"
 
-        with patch('subprocess.run') as mock_run:
+        with patch('subprocess.run') as mock_run, \
+             patch('pathlib.Path.exists', return_value=True):
             # Claude Code利用不可をシミュレート
             mock_run.side_effect = FileNotFoundError("claude command not found")
 


### PR DESCRIPTION
## 概要
ref-netプロジェクトのAI要約機能において、Claude Codeを使用する際に`~/.claude/.credentials.json`をマウントして認証を行えるよう改善しました。

## 変更内容
- Docker ComposeでClaude認証情報ファイルのマウント設定を追加
- ClaudeCodeClientで認証情報ファイルパスの存在確認を実装
- Claude Code実行時の環境変数設定（HOME=/root）を追加
- AI統合ドキュメントにClaude認証設定手順を追加
- テストでのファイルアクセスモック化による問題解決

## ドキュメント
- [x] AI統合ドキュメント（Claude認証設定手順追加）

## テスト
- [x] moon :check が正常終了する
- [x] Claude Codeクライアントのテストでファイルアクセス問題を修正

## 関連Issues
Closes #

## チェックリスト
- [x] コードがプロジェクトのコーディング規約に従っている
- [x] コードの自己レビューを完了
- [x] ドキュメントを更新（必要な場合）
- [x] 破壊的変更がない（または破壊的変更が文書化されている）
- [x] コミットメッセージが規約に従っている

## デプロイメント注意事項
- ホストマシンで事前に`claude`コマンドによる認証が必要
- `~/.claude/.credentials.json`ファイルが存在することを確認
- `AI_PROVIDER=claude-code`環境変数でClaude Codeを優先使用可能

🤖 Generated with [Claude Code](https://claude.ai/code)